### PR TITLE
[gen]: rolling back to upper-constraints and sphinx 4.x

### DIFF
--- a/doc/ref_arch/kubernetes/conf.py
+++ b/doc/ref_arch/kubernetes/conf.py
@@ -20,11 +20,8 @@ linkcheck_ignore = [
     "https://www.iso.org/obp/ui/#iso:std:iso-iec:27002:ed-2:v1:en",
     "https://www.iso.org/obp/ui/#iso:std:iso-iec:27032:ed-1:v1:en",
     "https://ntia.gov/page/software-bill-materials",
-    "https://www.cisecurity.org/controls/cis-controls-list"
-]
-
-linkcheck_anchors_ignore_for_url = [
-    "https://github.com/cnti-testcatalog/testsuite/blob/main/RATIONALE.md"
+    "https://www.cisecurity.org/controls/cis-controls-list",
+    'https://github.com/cnti-testcatalog/testsuite/blob/main/RATIONALE.md#'
 ]
 
 intersphinx_mapping = {

--- a/doc/ref_arch/kubernetes/test-requirements.txt
+++ b/doc/ref_arch/kubernetes/test-requirements.txt
@@ -1,7 +1,7 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-sphinx==7.2.6 # BSD
+sphinx==4.5.0 # BSD
 doc8==0.11.2 # Apache-2.0
 piccolo-theme==0.21.0 # MIT
 sphinxcontrib-bibtex==2.5.0

--- a/doc/ref_arch/kubernetes/test-requirements.txt
+++ b/doc/ref_arch/kubernetes/test-requirements.txt
@@ -6,3 +6,8 @@ doc8==0.11.2 # Apache-2.0
 piccolo-theme==0.21.0 # MIT
 sphinxcontrib-bibtex==2.5.0
 pybtex==0.24.0
+sphinxcontrib-devhelp===1.0.2
+sphinxcontrib-applehelp===1.0.2
+sphinxcontrib-htmlhelp===2.0.0
+sphinxcontrib-qthelp===1.0.3
+sphinxcontrib-serializinghtml===1.1.5

--- a/doc/ref_arch/kubernetes/tox.ini
+++ b/doc/ref_arch/kubernetes/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 [testenv:docs]
 basepython = python3.10
 deps =
+  -chttps://opendev.org/openstack/requirements/raw/branch/stable/zed/upper-constraints.txt
   -r{toxinidir}/test-requirements.txt
 install_command = pip install {opts} {packages}
 allowlist_externals =


### PR DESCRIPTION
Rolling back to a linkcheck solution working with GitHub, but does not require Sphinx 7.x, so the usage of OpenStack upper constratins can be reintroduced.  