### PR TITLE
update to k8s 1.33

### DIFF
--- a/.vale/config/vocabularies/Anuket/accept.txt
+++ b/.vale/config/vocabularies/Anuket/accept.txt
@@ -9,6 +9,7 @@
 [Cc]groups
 Ceph
 CNF
+CNFs
 CNI
 CSI
 [Cc]onfig

--- a/doc/ref_arch/kubernetes/chapters/chapter01.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter01.rst
@@ -22,7 +22,7 @@ To assist with the goal of creating a reference architecture that will support T
 leverage the work that already has been completed in the Kubernetes community, RA2 will take an "RA2 Razor" approach to
 build the foundation. This can be explained along the lines of "if something is useful for non-Telecom workloads, we
 will not include it only for Telecom workloads". For example, start the Reference Architecture from a vanilla Kubernetes
-(say, v1.31) feature set, then provide clear evidence that a functional requirement cannot be met by that system
+(say, v1.33) feature set, then provide clear evidence that a functional requirement cannot be met by that system
 (say, multi-NIC support), only then the RA would add the least invasive, Kubernetes-community aligned extension
 (say, Multus) to fill the gap. If there are still gaps that cannot be filled by standard Kubernetes community
 technologies or extensions then the RA will concisely record the requirement in the
@@ -41,7 +41,7 @@ Required Component Versions
 ========== ===================
 Component  Required version(s)
 ========== ===================
-Kubernetes 1.31
+Kubernetes 1.33
 ========== ===================
 
 Principles

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -941,6 +941,11 @@ Cloud Infrastructure Security Requirements
      - The Cloud Infrastructure architecture **should** rely on Zero Trust principles to build a secure by design
        environment.
      -
+   * - Platform and Access
+     - sec.sys.021
+     - The Platform **should** support User Namespaces to isolate Pod users from the node's users, preventing
+       container-to-host privilege escalation.
+     - :ref:`chapters/chapter05:user namespaces for enhanced isolation`
    * - Confidentiality and Integrity
      - sec.ci.001
      - The Platform **must** support Confidentiality and Integrity of data at rest and in-transit. by design

--- a/doc/ref_arch/kubernetes/chapters/chapter02.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter02.rst
@@ -943,7 +943,7 @@ Cloud Infrastructure Security Requirements
      -
    * - Platform and Access
      - sec.sys.021
-     - The Platform **should** support User Namespaces to isolate Pod users from the node's users, preventing
+     - The Platform **must** support User Namespaces to isolate Pod users from the node's users, preventing
        container-to-host privilege escalation.
      - :ref:`chapters/chapter05:user namespaces for enhanced isolation`
    * - Confidentiality and Integrity

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -460,6 +460,12 @@ the following specifications:
      - e.man.006, e.man.007, e.man.008, e.man.009 :cite:t:`refmodel` Chapter 9, section Cloud Infrastructure Management
        Capabilities
      -
+   * - ra2.k8s.024
+     - Sidecar Containers
+     - An implementation must support sidecar containers. This feature is needed for deploying service mesh proxies,
+       log shippers, and other supporting processes with CNFs.
+     - TBC
+     -
 
 Container Runtimes
 ------------------

--- a/doc/ref_arch/kubernetes/chapters/chapter04.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter04.rst
@@ -687,8 +687,8 @@ Architecture they must be implemented according to the following specifications:
      -
    * - ra2.stg.006
      - Container Storage Interface (CSI)
-     - An implementation may support the Container Storage Interface (CSI). In-tree storage plugins for Ceph have been
-       removed in Kubernetes 1.31, so corresponding CSI drivers must be used. To support CSI, the
+     - An implementation may support the Container Storage Interface (CSI). CSI drivers must be used as in-tree volume
+       plugins are deprecated and have been removed. To support CSI, the
        feature gates CSIDriverRegistry and CSINodeInfo must be enabled. The implementation must use a CSI driver
        (full list of CSI drivers :cite:p:`k8s-csi-drivers`). An implementation may support ephemeral storage through a
        CSI-compatible volume plugin. In this case, the CSIInlineVolume feature gate must be enabled. An implementation

--- a/doc/ref_arch/kubernetes/chapters/chapter05.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter05.rst
@@ -295,7 +295,7 @@ namespace where the internal user (e.g., root) is mapped to a high-numbered, non
 isolation ensures that even if an attacker compromises a container running as root, they do not have root privileges on
 the host node, significantly limiting their ability to cause damage.
 
-Given the substantial security benefits, the platform **should** have the User Namespaces feature enabled to enhance
+Starting with Kubernetes 1.33, the platform will have the User Namespaces feature enabled to enhance
 workload isolation and enforce the principle of least privilege at the host level.
 
 Secrets Management

--- a/doc/ref_arch/kubernetes/chapters/chapter05.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter05.rst
@@ -283,6 +283,21 @@ Container runtime best practices include:
 - Do not run applications with root privileges.
 - Properly segment sensitive workloads using namespaces or clusters to limit the impact of compromises.
 
+User Namespaces for Enhanced Isolation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A primary security concern in containerized environments is a container breakout, where an attacker escapes the
+container's boundaries to gain control over the underlying host. A key enabler for this is when a container runs as the
+root user, as this user ID (UID 0) is the same as the root user on the host.
+
+The User Namespaces feature in Kubernetes directly mitigates this risk. It allows a Pod to run in a separate user
+namespace where the internal user (e.g., root) is mapped to a high-numbered, non-privileged user on the host. This
+isolation ensures that even if an attacker compromises a container running as root, they do not have root privileges on
+the host node, significantly limiting their ability to cause damage.
+
+Given the substantial security benefits, the platform **should** have the User Namespaces feature enabled to enhance
+workload isolation and enforce the principle of least privilege at the host level.
+
 Secrets Management
 ------------------
 

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -375,7 +375,7 @@ Node Special Interest Group :cite:p:`k8s-api-sig-node`
      -
      - Resource tracking for 0 pods per node.
    * - Feature:SidecarContainers :cite:p:`k8s-feature-gates`
-     -
+     - X
      - Allow setting the restartPolicy of an init container to Always so that
        the container becomes a sidecar container (restartable init containers).
    * - Feature:UserNamespacesSupport :cite:p:`k8s-feature-gates`
@@ -754,7 +754,6 @@ skip:
 -  [Feature:PodGarbageCollector]
 -  [Feature:PodLifecycleSleepAction]
 -  [Feature:RegularResourceUsageTracking]
--  [Feature:SidecarContainers]
 -  [Feature:UserNamespacesSupport]
 -  [Feature:UserNamespacesStatelessPodsSupport]
 -  [NodeFeature:DownwardAPIHugePages]

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -49,7 +49,7 @@ In these Reference Architecture APIs, only those APIs which are in any of the fo
 
 The Kubernetes API reference is available here :cite:p:`k8s-api-reference`.
 
-The list of :cite:p:`k8s-v1.31-api-groups` that are mandatory is as follows:
+The list of :cite:p:`k8s-v1.33-api-groups` that are mandatory is as follows:
 
 .. list-table:: Mandatory API Groups
    :widths: 30 30

--- a/doc/ref_arch/kubernetes/chapters/chapter06.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter06.rst
@@ -379,7 +379,7 @@ Node Special Interest Group :cite:p:`k8s-api-sig-node`
      - Allow setting the restartPolicy of an init container to Always so that
        the container becomes a sidecar container (restartable init containers).
    * - Feature:UserNamespacesSupport :cite:p:`k8s-feature-gates`
-     -
+     - X
      - Enable user namespace support for Pods.
    * - Feature: ProbeTerminationGracePeriod :cite:p:`k8s-feature-probeterminationgraceperiod`
      - X
@@ -754,7 +754,6 @@ skip:
 -  [Feature:PodGarbageCollector]
 -  [Feature:PodLifecycleSleepAction]
 -  [Feature:RegularResourceUsageTracking]
--  [Feature:UserNamespacesSupport]
 -  [Feature:UserNamespacesStatelessPodsSupport]
 -  [NodeFeature:DownwardAPIHugePages]
 -  [NodeFeature:RuntimeHandler]

--- a/doc/ref_arch/kubernetes/chapters/chapter07.rst
+++ b/doc/ref_arch/kubernetes/chapters/chapter07.rst
@@ -185,12 +185,13 @@ Requirements, Chapter 2 of :cite:t:`anuket-ra1`)
 
 **Baseline project:** *Kubernetes*
 
-**Gap description:** Kubernetes lacks namespace-scoped UIDs.
-CNFs requiring system privileges must run in privileged
-mode or use random system UIDs. Random UIDs cause errors
-when setting kernel capabilities (e.g., VLAN trunking) or
-sharing data via persistent storage.  Privileged mode is
-insecure; random UIDs are error-prone.  Proper user
-namespaces (alpha in Kubernetes 1.25
-:cite:t:`kubernetes-user-namespaces`, KEP
-:cite:t:`kubernetes-kep-user-namespaces`) are needed.
+**Gap description:** Kubernetes has historically lacked a mechanism to isolate the user within a container from the
+host's user, meaning a container running as root (UID 0) was also seen as root by the host kernel. This creates a
+significant security risk.
+
+**Status**: This gap is now being addressed. The User Namespaces feature, which graduated to Beta and is enabled by
+default in Kubernetes v1.33, allows re-mapping the user inside the Pod to a different, non-privileged user range on the
+node. This means a container can run as root internally while being mapped to a harmless user externally,
+drastically reducing the attack surface for privilege escalation. While the feature is still Beta, its default-on
+status makes it a viable solution for enhancing workload isolation. This RA recommends its adoption to satisfy security
+requirements for multitenancy.

--- a/doc/ref_arch/kubernetes/conf.py
+++ b/doc/ref_arch/kubernetes/conf.py
@@ -13,6 +13,8 @@ extensions = [
 
 html_theme = "piccolo_theme"
 
+linkcheck_retries = 3
+
 linkcheck_ignore = [
     "https://github.com/cncf/cnf-testsuite/blob/main/RATIONALE.md",
     "https://github.com/opencontainers/runtime-spec/blob/master/config.md",

--- a/doc/ref_arch/kubernetes/refs.bib
+++ b/doc/ref_arch/kubernetes/refs.bib
@@ -659,9 +659,9 @@
     url = {https://kubernetes.io/docs/reference/kubernetes-api/}
 }
 
-@misc{k8s-v1.31-api-groups,
+@misc{k8s-v1.33-api-groups,
     title = {Kubernetes API Groups},
-    url = {https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/}
+    url = {https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/}
 }
 
 @misc{k8s-api-sig-api-machinery,


### PR DESCRIPTION
fixes [#3466](https://github.com/anuket-project/anuket-specifications/issues/3466)

- updated release and API groups ref
- Sidecar Containers: made this a mandatory feature in the reference architecture, as it is now stable in Kubernetes. This ensures reliable support for common CNF patterns like service mesh and logging.
- User Namespaces: elevated this from a "gap" to a core security recommendation. This is now a default-on beta feature in Kubernetes, preventing container-to-host privilege escalation.